### PR TITLE
Add npm start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use NPM to get the dependencies and then build with webpack:
 
 ```
 npm install
-webpack --watch
+npm start -- --watch
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"description": "",
 	"main": "source/Flare.js",
 	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"start": "webpack"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Installing the project dependencies does not provide the
user with a global webpack command so the setup instructions
don't work if you do not already have webpack-cli installed
globally. This change adds an npm command that will run the
locally installed webpack so there are no additional setup
steps required.