### PR TITLE
Fixing setMatrix to concat.

### DIFF
--- a/source/Graphics.js
+++ b/source/Graphics.js
@@ -158,7 +158,7 @@ export default class Graphics
 
 	setView(matrix)
 	{
-		this._SkCanvas.setMatrix(
+		this._SkCanvas.concat(
 			[matrix[0], matrix[2], matrix[4],
 			matrix[1], matrix[3], matrix[5],
 			0, 0,  1]);


### PR DESCRIPTION
`setMatrix` removed and changed to `concat` function on CanvasKit.
https://github.com/google/skia/commit/92d8ea6f993043a3d1513ee62bfd70a774edf52d