### PR TITLE
Add markDirty for ActorPaint #10

### DIFF
--- a/source/ActorNode.js
+++ b/source/ActorNode.js
@@ -1,9 +1,6 @@
 import ActorComponent from "./ActorComponent.js";
 import {vec2, mat2d} from "gl-matrix";
-
-
-const TransformDirty = 1<<0;
-const WorldTransformDirty = 1<<1;
+import {DirtyFlags} from "./DirtyFlags.js";
 
 function _UpdateTransform(node)
 {
@@ -136,11 +133,11 @@ export default class ActorNode extends ActorComponent
 			// Still loading?
 			return;
 		}
-		if(!actor.addDirt(this, TransformDirty))
+		if(!actor.addDirt(this, DirtyFlags.TransformDirty))
 		{
 			return;
 		}
-		actor.addDirt(this, WorldTransformDirty, true);
+		actor.addDirt(this, DirtyFlags.WorldTransformDirty, true);
 	}
 
 	updateWorldTransform()
@@ -287,11 +284,11 @@ export default class ActorNode extends ActorComponent
 
 	update(dirt)
 	{
-		if((dirt & TransformDirty) === TransformDirty)
+		if((dirt & DirtyFlags.TransformDirty) === DirtyFlags.TransformDirty)
 		{
 			_UpdateTransform(this);
 		}
-		if((dirt & WorldTransformDirty) === WorldTransformDirty)
+		if((dirt & DirtyFlags.WorldTransformDirty) === DirtyFlags.WorldTransformDirty)
 		{
 			this.updateWorldTransform();
 			let constraints = this._Constraints;
@@ -310,7 +307,7 @@ export default class ActorNode extends ActorComponent
 
 	getWorldTransform()
 	{
-		if((this._DirtMask & WorldTransformDirty) !== WorldTransformDirty)
+		if((this._DirtMask & DirtyFlags.WorldTransformDirty) !== DirtyFlags.WorldTransformDirty)
 		{
 			return this._WorldTransform;
 		}
@@ -326,11 +323,11 @@ export default class ActorNode extends ActorComponent
 		{
 			if(item.hasWorldTransform)
 			{
-				if((this._DirtMask & TransformDirty) !== TransformDirty)
+				if((this._DirtMask & DirtyFlags.TransformDirty) !== DirtyFlags.TransformDirty)
 				{
 					_UpdateTransform(this);
 				}
-				if((this._DirtMask & WorldTransformDirty) !== WorldTransformDirty)
+				if((this._DirtMask & DirtyFlags.WorldTransformDirty) !== DirtyFlags.WorldTransformDirty)
 				{
 					item.updateWorldTransform();
 				}

--- a/source/ActorNode.js
+++ b/source/ActorNode.js
@@ -1,6 +1,8 @@
 import ActorComponent from "./ActorComponent.js";
 import {vec2, mat2d} from "gl-matrix";
-import {DirtyFlags} from "./DirtyFlags.js";
+import DirtyFlags from "./DirtyFlags.js";
+
+const {WorldTransformDirty, TransformDirty} = DirtyFlags;
 
 function _UpdateTransform(node)
 {
@@ -133,11 +135,11 @@ export default class ActorNode extends ActorComponent
 			// Still loading?
 			return;
 		}
-		if(!actor.addDirt(this, DirtyFlags.TransformDirty))
+		if(!actor.addDirt(this, TransformDirty))
 		{
 			return;
 		}
-		actor.addDirt(this, DirtyFlags.WorldTransformDirty, true);
+		actor.addDirt(this, WorldTransformDirty, true);
 	}
 
 	updateWorldTransform()
@@ -284,11 +286,11 @@ export default class ActorNode extends ActorComponent
 
 	update(dirt)
 	{
-		if((dirt & DirtyFlags.TransformDirty) === DirtyFlags.TransformDirty)
+		if((dirt & TransformDirty) === TransformDirty)
 		{
 			_UpdateTransform(this);
 		}
-		if((dirt & DirtyFlags.WorldTransformDirty) === DirtyFlags.WorldTransformDirty)
+		if((dirt & WorldTransformDirty) === WorldTransformDirty)
 		{
 			this.updateWorldTransform();
 			let constraints = this._Constraints;
@@ -307,7 +309,7 @@ export default class ActorNode extends ActorComponent
 
 	getWorldTransform()
 	{
-		if((this._DirtMask & DirtyFlags.WorldTransformDirty) !== DirtyFlags.WorldTransformDirty)
+		if((this._DirtMask & WorldTransformDirty) !== WorldTransformDirty)
 		{
 			return this._WorldTransform;
 		}
@@ -323,11 +325,11 @@ export default class ActorNode extends ActorComponent
 		{
 			if(item.hasWorldTransform)
 			{
-				if((this._DirtMask & DirtyFlags.TransformDirty) !== DirtyFlags.TransformDirty)
+				if((this._DirtMask & TransformDirty) !== TransformDirty)
 				{
 					_UpdateTransform(this);
 				}
-				if((this._DirtMask & DirtyFlags.WorldTransformDirty) !== DirtyFlags.WorldTransformDirty)
+				if((this._DirtMask & WorldTransformDirty) !== WorldTransformDirty)
 				{
 					item.updateWorldTransform();
 				}

--- a/source/Animation.js
+++ b/source/Animation.js
@@ -432,6 +432,7 @@ export default class Animation
 						{
 							component._Opacity = component._Opacity * imix + value * mix;
 						}
+						component.markDirty();
 						break;
 					case AnimatedPropertyTypes.FillColor:
 					case AnimatedPropertyTypes.StrokeColor:
@@ -451,6 +452,7 @@ export default class Animation
 							color[2] = color[2] * imix + value[2] * mix;
 							color[3] = color[3] * imix + value[3] * mix;
 						}
+						component.markDirty();
 						break;
 					}
 					case AnimatedPropertyTypes.FillGradient:
@@ -487,6 +489,7 @@ export default class Animation
 								wi++;
 							}
 						}
+						component.markDirty();
 						break;
 					}
 					case AnimatedPropertyTypes.FillRadial:
@@ -525,6 +528,7 @@ export default class Animation
 								wi++;
 							}
 						}
+						component.markDirty();
 						break;
 					}
 					case AnimatedPropertyTypes.ShapeHeight:

--- a/source/ColorComponent.js
+++ b/source/ColorComponent.js
@@ -4,7 +4,9 @@ import FillRule from "./FillRule.js";
 import StrokeCap from "./StrokeCap.js";
 import StrokeJoin from "./StrokeJoin.js";
 import Graphics from "./Graphics.js";
-import {DirtyFlags} from "./DirtyFlags.js";
+import DirtyFlags from "./DirtyFlags.js";
+
+const {PaintDirty} = DirtyFlags;
 
 class ActorPaint extends ActorComponent
 {
@@ -17,7 +19,7 @@ class ActorPaint extends ActorComponent
 	
 	markDirty()
 	{
-		this._Actor.addDirt(this, DirtyFlags.ColorDirty, true);
+		this._Actor.addDirt(this, PaintDirty, true);
 	}
 
 	copy(node, resetActor)

--- a/source/ColorComponent.js
+++ b/source/ColorComponent.js
@@ -4,6 +4,7 @@ import FillRule from "./FillRule.js";
 import StrokeCap from "./StrokeCap.js";
 import StrokeJoin from "./StrokeJoin.js";
 import Graphics from "./Graphics.js";
+import {DirtyFlags} from "./DirtyFlags.js";
 
 class ActorPaint extends ActorComponent
 {
@@ -14,6 +15,11 @@ class ActorPaint extends ActorComponent
 		this._Opacity = 1.0;
 	}
 	
+	markDirty()
+	{
+		this._Actor.addDirt(this, DirtyFlags.ColorDirty, true);
+	}
+
 	copy(node, resetActor)
 	{
 		super.copy(node, resetActor);

--- a/source/DirtyFlags.js
+++ b/source/DirtyFlags.js
@@ -1,7 +1,6 @@
-export const DirtyFlags = Object.freeze(
-    {
-        "TransformDirty": 1<<0,
-        "WorldTransformDirty": 1<<1,
-        "ColorDirty": 1<<2
-    }
-);
+export default class DirtyFlags
+{
+    static get TransformDirty() { return 1<<0; }
+    static get WorldTransformDirty() { return 1<<1; }
+    static get PaintDirty() { return 1<<2; }
+}

--- a/source/DirtyFlags.js
+++ b/source/DirtyFlags.js
@@ -1,0 +1,7 @@
+export const DirtyFlags = Object.freeze(
+    {
+        "TransformDirty": 1<<0,
+        "WorldTransformDirty": 1<<1,
+        "ColorDirty": 1<<2
+    }
+);


### PR DESCRIPTION
Allow color components to raise their own flag, and mark them dirty when applying the animation.
Move Dirty Flags to their own file.